### PR TITLE
feat: Add `match` and `unwrap` methods to `result`

### DIFF
--- a/.changeset/tricky-pandas-promise.md
+++ b/.changeset/tricky-pandas-promise.md
@@ -1,0 +1,5 @@
+---
+"ts-blocks": minor
+---
+
+Add `match` and `unwrap` methods to `result`.

--- a/blocks/types/result.test.ts
+++ b/blocks/types/result.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'vitest';
-import { Err, Ok, type Result } from './result';
+import { assert, expect, test } from 'vitest';
+import { Err, Ok, type Result, match, unwrap } from './result';
 
 const failingFunction = <E>(err: E): Result<boolean, E> => Err(err);
 
@@ -17,4 +17,38 @@ test('Expect correct failed result', () => {
 
 	expect(val).toBe(null);
 	expect(err).toBe('I failed!');
+});
+
+test('Expect pass value from match', () => {
+	const res = match(
+		passingFunction(true),
+		(val) => val,
+		() => {
+			throw new Error('This should not throw');
+		}
+	);
+
+	expect(res).toBe(true);
+});
+
+test('Expect fail value from match', () => {
+	const res = match(
+		failingFunction('I failed!'),
+		() => {
+			throw new Error('This should have thrown');
+		},
+		(err) => err
+	);
+
+	expect(res).toBe('I failed!');
+});
+
+test('Expect pass value from unwrap', () => {
+	const res = unwrap(passingFunction(true));
+
+	expect(res).toBe(true);
+});
+
+test('Expect fail value from unwrap', () => {
+	assert.throws(() => unwrap(failingFunction('I failed!')), 'I failed!');
 });

--- a/blocks/types/result.ts
+++ b/blocks/types/result.ts
@@ -6,9 +6,7 @@
  *
  * ## Examples
  * ```ts
- * const functionThatCanFail = (): Result<number, string> => {
- *      //...
- * }
+ * const functionThatCanFail = (): Result<number, string> => {}
  *
  * const [val, err] = functionThatCanFail();
  *
@@ -38,4 +36,66 @@ const Ok = <T>(val: T): Result<T, never> => [val, null];
  */
 const Err = <E>(err: E): Result<never, E> => [null, err];
 
-export { type Result, Ok, Err };
+/** A helper method for the `Result<T, E>` type to allow you to pattern match on a Result and requires you to handle all cases.
+ *
+ * @param res The result
+ * @param success Function to be called if the result is `Ok`
+ * @param failure Function to be called if the result is `Err`
+ * @returns
+ *
+ * ## Examples
+ *
+ * ```ts
+ * const functionThatCanFail = (): Result<number, string> => {
+ *  return Ok(10);
+ * };
+ *
+ * const value = match(
+ * 	functionThatCanFail(),
+ * 	(val) => val,
+ * 	(err) => {
+ * 		throw new Error(err);
+ * 	}
+ * );
+ *
+ * console.log(value) // 10
+ * ```
+ */
+const match = <T, V, E>(res: Result<V, E>, success: (val: V) => T, failure: (err: E) => T): T => {
+	const [val, err] = res;
+
+	if (err !== null) {
+		return failure(err);
+	}
+
+	// we know this matches because of the typing of Result
+	return success(val as V);
+};
+
+/** Tries to return the value if it can't it will throw.
+ *
+ * @param res The result
+ * @returns
+ *
+ * ## Examples
+ * ```ts
+ * const functionThatCanFail = () => {
+ *   return Ok(10);
+ * }
+ *
+ * const value = unwrap(functionThatCanFail());
+ *
+ * console.log(value) // 10
+ * ```
+ */
+const unwrap = <T, E>(res: Result<T, E>): T => {
+	const [val, err] = res;
+
+	if (err !== null) {
+		throw new Error(JSON.stringify(err));
+	}
+
+	return val as T;
+};
+
+export { type Result, Ok, Err, match, unwrap };

--- a/blocks/utilities/sleep.test.ts
+++ b/blocks/utilities/sleep.test.ts
@@ -5,7 +5,7 @@ import { sleep } from './sleep';
 test('Expect time elapsed', async () => {
 	const start = Date.now();
 
-	const duration = 25;
+	const duration = 50;
 
 	await sleep(duration);
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/ts-blocks"
 	},
-	"keywords": [
-		"changelog",
-		"date"
-	],
+	"keywords": ["changelog", "date"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {


### PR DESCRIPTION
Adds `match` and `unwrap` error helper methods to `result`