### PR TITLE
feat: Dispatcher block

### DIFF
--- a/.changeset/friendly-bags-film.md
+++ b/.changeset/friendly-bags-film.md
@@ -1,0 +1,5 @@
+---
+"ts-blocks": minor
+---
+
+Changed default value for `includeTests` to be false because in practice I am normally turning it off to run remote tests anyways.

--- a/.changeset/lovely-comics-try.md
+++ b/.changeset/lovely-comics-try.md
@@ -1,0 +1,5 @@
+---
+"ts-blocks": minor
+---
+
+Add `dispatcher` block

--- a/.changeset/tough-gifts-hunt.md
+++ b/.changeset/tough-gifts-hunt.md
@@ -1,0 +1,5 @@
+---
+"ts-blocks": minor
+---
+
+Add `imports` option to config to allow you to configure the import style.

--- a/blocks/utilities/dispatcher.test.ts
+++ b/blocks/utilities/dispatcher.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from 'vitest';
+import { newDispatcher } from './dispatcher';
+
+test('Expect subscribe then unsubscribe', () => {
+	const dispatcher = newDispatcher();
+
+	let count = 0;
+
+	const dispatcherId = dispatcher.addListener(() => {
+		count += 2;
+	});
+
+	dispatcher.emit();
+
+	expect(count).toBe(2);
+
+	dispatcher.removeListener(dispatcherId);
+
+	dispatcher.emit();
+
+	expect(count).toBe(2);
+});
+
+test('Expect all subscribe then all unsubscribe', () => {
+	const dispatcher = newDispatcher();
+
+	let count = 0;
+
+	dispatcher.addListener(() => {
+		count += 2;
+	});
+	dispatcher.addListener(() => {
+		count += 2;
+	});
+
+	dispatcher.emit();
+
+	expect(count).toBe(4);
+
+	dispatcher.removeAllListeners();
+
+	dispatcher.emit();
+
+	expect(count).toBe(4);
+});
+
+test('Expect all subscribe then one unsubscribe', () => {
+	const dispatcher = newDispatcher();
+
+	let count = 0;
+
+	const firstId = dispatcher.addListener(() => {
+		count += 2;
+	});
+	dispatcher.addListener(() => {
+		count += 5;
+	});
+
+	dispatcher.emit();
+
+	expect(count).toBe(7);
+
+	dispatcher.removeListener(firstId);
+
+	dispatcher.emit();
+
+	expect(count).toBe(12);
+});
+
+test('Expect all receive params', () => {
+	const dispatcher = newDispatcher<{ currentCount: number }>();
+
+	let count = 2;
+
+	dispatcher.addListener((opts) => {
+		if (opts === undefined) return;
+
+		count = opts.currentCount + 2;
+	});
+
+	dispatcher.emit({ currentCount: count });
+
+	expect(count).toBe(4);
+});

--- a/blocks/utilities/dispatcher.ts
+++ b/blocks/utilities/dispatcher.ts
@@ -1,0 +1,127 @@
+export type ListenerCallback<T = undefined> = T extends undefined ? () => void : (opts: T) => void;
+
+/** Simplifies adding event listeners to your code.
+ *
+ * ## Examples
+ *
+ * ```ts
+ * import { newDispatcher } from "./src/blocks/dispatcher";
+ *
+ * const dispatcher = newDispatcher();
+ *
+ * let count = 0;
+ *
+ * dispatcher.addListener(() => { count += 2; });
+ *
+ * dispatcher.emit();
+ *
+ * console.log(count); // 2
+ *
+ * dispatcher.addListener(() => { count += 4; });
+ *
+ * dispatcher.emit();
+ *
+ * console.log(count); // 8
+ * ```
+ *
+ * ### Typed Options
+ *
+ * ```ts
+ * import { newDispatcher } from "./src/blocks/dispatcher";
+ *
+ * const dispatcher = newDispatcher<string>();
+ *
+ * dispatcher.addListener((name) => { console.log(`Hello ${name}!`) });
+ *
+ * dispatcher.emit("John"); // 'Hello John!'
+ * ```
+ */
+export type Dispatcher<T = undefined> = {
+	/** Adds an event listener
+	 *
+	 * @param callback
+	 * @returns
+	 *
+	 * ## Usage
+	 *
+	 * ```ts
+	 * const listenerId = dispatcher.addListener(() => { ... });
+	 * ```
+	 */
+	addListener: (callback: ListenerCallback<T>) => number;
+	/** Removes an event listener
+	 *
+	 * @param id
+	 * @returns
+	 *
+	 * ## Usage
+	 *
+	 * ```ts
+	 * dispatcher.removeListener(listenerId);
+	 * ```
+	 */
+	removeListener: (id: number) => void;
+	/** Emits an event to all listeners with the provided options.
+	 *
+	 * @param opts Options to be passed to the listener
+	 * @returns `void`
+	 *
+	 * ## Usage
+	 *
+	 * ```ts
+	 * dispatcher.emit();
+	 * ```
+	 *
+	 */
+	emit: T extends undefined ? () => void : (opts: T) => void;
+	/** Removes all event listeners from the dispatcher.
+	 *
+	 * @returns
+	 *
+	 * ## Usage
+	 *
+	 * ```ts
+	 * dispatcher.removeAllListeners();
+	 * ```
+	 */
+	removeAllListeners: () => void;
+};
+
+/** Create a new dispatcher instance.
+ *
+ * @returns
+ *
+ * ## Usage
+ *
+ * ```ts
+ * const dispatcher = newDispatcher();
+ * ```
+ */
+const newDispatcher = <T = undefined>(): Dispatcher<T> => {
+	let nextListenerId = 0;
+	const listeners = new Map<number, ListenerCallback<T>>();
+
+	return {
+		addListener: (callback) => {
+			nextListenerId++;
+			listeners.set(nextListenerId, callback);
+			return nextListenerId;
+		},
+		removeListener: (listenerId: number) => listeners.delete(listenerId),
+		emit: ((opts?: T) => {
+			for (const [_, callback] of listeners) {
+				if (opts === undefined) {
+					(callback as ListenerCallback<undefined>)();
+				} else {
+					callback(opts);
+				}
+			}
+		}) as Dispatcher<T>['emit'],
+		removeAllListeners: () => {
+			listeners.clear();
+			nextListenerId = 0;
+		},
+	};
+};
+
+export { newDispatcher };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/ts-blocks"
 	},
-	"keywords": ["changelog", "date"],
+	"keywords": [
+		"changelog",
+		"date"
+	],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {
@@ -40,7 +43,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"@types/node": "^22.7.6",
+		"@types/node": "^22.7.7",
 		"typedoc": "^0.26.10",
 		"typescript": "^5.6.3",
 		"unbuild": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/ts-blocks"
 	},
-	"keywords": [
-		"changelog",
-		"date"
-	],
+	"keywords": ["changelog", "date"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@types/node':
-        specifier: ^22.7.6
-        version: 22.7.6
+        specifier: ^22.7.7
+        version: 22.7.7
       typedoc:
         specifier: ^0.26.10
         version: 0.26.10(typescript@5.6.3)
@@ -56,7 +56,7 @@ importers:
         version: 2.0.0(typescript@5.6.3)
       vitest:
         specifier: ^2.1.3
-        version: 2.1.3(@types/node@22.7.6)
+        version: 2.1.3(@types/node@22.7.7)
 
 packages:
 
@@ -896,8 +896,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.7.6':
-    resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
+  '@types/node@22.7.7':
+    resolution: {integrity: sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -2968,7 +2968,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.7.6':
+  '@types/node@22.7.7':
     dependencies:
       undici-types: 6.19.8
 
@@ -2985,13 +2985,13 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.3(@types/node@22.7.6))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.3(@types/node@22.7.7))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
-      vite: 5.4.3(@types/node@22.7.6)
+      vite: 5.4.3(@types/node@22.7.7)
 
   '@vitest/pretty-format@2.1.3':
     dependencies:
@@ -4277,12 +4277,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.1.3(@types/node@22.7.6):
+  vite-node@2.1.3(@types/node@22.7.7):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.4.3(@types/node@22.7.6)
+      vite: 5.4.3(@types/node@22.7.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4294,19 +4294,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.3(@types/node@22.7.6):
+  vite@5.4.3(@types/node@22.7.7):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.45
       rollup: 4.21.2
     optionalDependencies:
-      '@types/node': 22.7.6
+      '@types/node': 22.7.7
       fsevents: 2.3.3
 
-  vitest@2.1.3(@types/node@22.7.6):
+  vitest@2.1.3(@types/node@22.7.7):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.3(@types/node@22.7.6))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.3(@types/node@22.7.7))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3
@@ -4321,11 +4321,11 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.3(@types/node@22.7.6)
-      vite-node: 2.1.3(@types/node@22.7.6)
+      vite: 5.4.3(@types/node@22.7.7)
+      vite-node: 2.1.3(@types/node@22.7.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.7.6
+      '@types/node': 22.7.7
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/schema.json
+++ b/schema.json
@@ -20,6 +20,11 @@
 			"description": "When true includes the test files for each function in the same directory.",
 			"type": "boolean",
 			"default": "true"
+		},
+		"imports": {
+			"description": "Controls the suffix when re-exporting from index.ts.",
+			"enum": ["deno", "node"],
+			"default": "node"
 		}
 	},
 	"required": ["path", "addByCategory", "includeIndexFile", "includeTests"]

--- a/src/blocks.ts
+++ b/src/blocks.ts
@@ -30,6 +30,9 @@ const blocks: Record<string, Block> = {
 	stopwatch: {
 		category: 'utilities',
 	},
+	dispatcher: {
+		category: 'utilities',
+	},
 };
 
 export { blocks };

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -119,7 +119,7 @@ const _add = async (blockNames: string[], options: Options) => {
 					index = project.createSourceFile(indexPath);
 				}
 
-				if (config.imports === undefined || config.imports === 'node') {
+				if (config.imports === 'node') {
 					index.addExportDeclaration({
 						moduleSpecifier: `./${blockName}`,
 						isTypeOnly: false,

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -7,7 +7,7 @@ import { execa } from 'execa';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
 import { Project, type SourceFile } from 'ts-morph';
-import { boolean, type InferInput, object, parse } from 'valibot';
+import { type InferInput, boolean, object, parse } from 'valibot';
 import { blocks } from '../blocks';
 import { getConfig } from '../config';
 import { INFO, WARN } from '../utils/index';

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -7,7 +7,7 @@ import { execa } from 'execa';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
 import { Project, type SourceFile } from 'ts-morph';
-import { type InferInput, boolean, object, parse } from 'valibot';
+import { boolean, type InferInput, object, parse } from 'valibot';
 import { blocks } from '../blocks';
 import { getConfig } from '../config';
 import { INFO, WARN } from '../utils/index';
@@ -82,7 +82,9 @@ const _add = async (blockNames: string[], options: Options) => {
 
 		if (fs.existsSync(newPath) && !options.yes) {
 			const result = await confirm({
-				message: `${color.bold(blockName)} already exists in your project would you like to overwrite it?`,
+				message: `${color.bold(
+					blockName
+				)} already exists in your project would you like to overwrite it?`,
 				initialValue: false,
 			});
 
@@ -117,10 +119,17 @@ const _add = async (blockNames: string[], options: Options) => {
 					index = project.createSourceFile(indexPath);
 				}
 
-				index.addExportDeclaration({
-					moduleSpecifier: `./${blockName}`,
-					isTypeOnly: false,
-				});
+				if (config.imports === undefined || config.imports === 'node') {
+					index.addExportDeclaration({
+						moduleSpecifier: `./${blockName}`,
+						isTypeOnly: false,
+					});
+				} else if (config.imports === 'deno') {
+					index.addExportDeclaration({
+						moduleSpecifier: `./${blockName}.ts`,
+						isTypeOnly: false,
+					});
+				}
 
 				index.saveSync();
 			} catch {
@@ -165,9 +174,9 @@ const _add = async (blockNames: string[], options: Options) => {
 					} catch {
 						program.error(
 							color.red(
-								`Failed to install ${color.bold('vitest')}! Failed while running '${color.bold(
-									installCommand
-								)}'`
+								`Failed to install ${color.bold(
+									'vitest'
+								)}! Failed while running '${color.bold(installCommand)}'`
 							)
 						);
 					}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import { cancel, intro, isCancel, outro, text } from '@clack/prompts';
 import color from 'chalk';
 import { Command } from 'commander';
-import { boolean, type InferInput, object, optional, parse, string } from 'valibot';
-import { type Config, CONFIG_NAME } from '../config';
+import { type InferInput, boolean, object, optional, parse, string } from 'valibot';
+import { CONFIG_NAME, type Config } from '../config';
 
 const schema = object({
 	path: optional(string()),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import { cancel, intro, isCancel, outro, text } from '@clack/prompts';
 import color from 'chalk';
 import { Command } from 'commander';
-import { type InferInput, boolean, object, optional, parse, string } from 'valibot';
-import { CONFIG_NAME, type Config } from '../config';
+import { boolean, type InferInput, object, optional, parse, string } from 'valibot';
+import { type Config, CONFIG_NAME } from '../config';
 
 const schema = object({
 	path: optional(string()),
@@ -26,7 +26,7 @@ const init = new Command('init')
 		'--no-index-file',
 		'Will create an index.ts file at the root of the folder to re-export functions from.'
 	)
-	.option('--no-tests', 'Will include tests along with the functions.')
+	.option('--tests', 'Will include tests along with the functions.', false)
 	.action(async (opts) => {
 		const options = parse(schema, opts);
 
@@ -57,12 +57,23 @@ const _init = async (options: Options) => {
 		options.path = result;
 	}
 
+	let isDeno = false;
+
+	// very trivially tries to detect whether you are in a deno project
+	try {
+		fs.readFileSync('deno.json');
+		isDeno = true;
+	} catch {
+		isDeno = false;
+	}
+
 	const config: Config = {
 		$schema: `https://unpkg.com/ts-blocks@${version}/schema.json`,
 		path: options.path,
 		addByCategory: options.addByCategory,
 		includeIndexFile: options.indexFile,
 		includeTests: options.tests,
+		imports: isDeno ? 'deno' : 'node',
 	};
 
 	fs.writeFileSync(CONFIG_NAME, `${JSON.stringify(config, null, '\t')}\n`);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,18 +1,7 @@
 import fs from 'node:fs';
 import color from 'chalk';
 import { program } from 'commander';
-import {
-	type InferInput,
-	boolean,
-	literal,
-	minLength,
-	object,
-	optional,
-	parse,
-	pipe,
-	string,
-	union,
-} from 'valibot';
+import { boolean, literal, minLength, object, optional, parse, pipe, string, union } from 'valibot';
 
 const CONFIG_NAME = 'blocks.json';
 
@@ -25,20 +14,37 @@ const schema = object({
 	imports: optional(union([literal('deno'), literal('node')])),
 });
 
-type Config = InferInput<typeof schema>;
+type Config = {
+	$schema: string;
+	addByCategory: boolean;
+	includeIndexFile: boolean;
+	includeTests: boolean;
+	path: string;
+	imports: 'deno' | 'node';
+};
 
-const getConfig = () => {
+const getConfig = (): Config => {
 	if (!fs.existsSync(CONFIG_NAME)) {
 		program.error(
 			color.red(
-				`Could not find your configuration file! Please run ${color.bold(`'ts-blocks init'`)}.`
+				`Could not find your configuration file! Please run ${color.bold(
+					`'ts-blocks init'`
+				)}.`
 			)
 		);
 	}
 
-	return parse(schema, JSON.parse(fs.readFileSync(CONFIG_NAME).toString()), {
+	const config = parse(schema, JSON.parse(fs.readFileSync(CONFIG_NAME).toString()), {
 		message: color.red('Invalid config file!'),
 	});
+
+	// set defaults here
+
+	if (config.imports === undefined) {
+		config.imports = 'node';
+	}
+
+	return config as Config;
 };
 
-export { getConfig, type Config, schema, CONFIG_NAME };
+export { type Config, CONFIG_NAME, getConfig, schema };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,18 @@
 import fs from 'node:fs';
 import color from 'chalk';
 import { program } from 'commander';
-import { type InferInput, boolean, minLength, object, parse, pipe, string } from 'valibot';
+import {
+	type InferInput,
+	boolean,
+	literal,
+	minLength,
+	object,
+	optional,
+	parse,
+	pipe,
+	string,
+	union,
+} from 'valibot';
 
 const CONFIG_NAME = 'blocks.json';
 
@@ -11,6 +22,7 @@ const schema = object({
 	includeIndexFile: boolean(),
 	includeTests: boolean(),
 	path: pipe(string(), minLength(1)),
+	imports: optional(union([literal('deno'), literal('node')])),
 });
 
 type Config = InferInput<typeof schema>;


### PR DESCRIPTION
The dispatcher block is nice because I have often found myself writing that same thing multiple times much easier to condense it into a reusable block like this.

- Also adds `Deno` support by adding an `imports` option to the config that will control the `.ts` suffix on the re-exports in the generated index file.
- Changes default value on initialization for `includeTests` to false