### PR TITLE
BREAKING: deprecate `imports` config option 

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,33 +1,33 @@
 {
-  "mode": "pre",
-  "tag": "next",
-  "initialVersions": {
-    "ts-blocks": "0.11.0"
-  },
-  "changesets": [
-    "brown-phones-know",
-    "empty-camels-smoke",
-    "fast-tips-grow",
-    "friendly-timers-repeat",
-    "good-bulldogs-mate",
-    "healthy-flies-argue",
-    "hip-rivers-swim",
-    "kind-eels-rescue",
-    "kind-news-decide",
-    "late-mails-allow",
-    "lazy-humans-compete",
-    "mean-owls-arrive",
-    "nasty-weeks-whisper",
-    "neat-moons-sparkle",
-    "neat-rockets-build",
-    "olive-cars-relax",
-    "polite-ligers-float",
-    "proud-bags-dance",
-    "shiny-dodos-battle",
-    "soft-mails-worry",
-    "thick-eggs-roll",
-    "tidy-queens-suffer",
-    "tough-crabs-jump",
-    "wise-pumpkins-bake"
-  ]
+	"mode": "pre",
+	"tag": "next",
+	"initialVersions": {
+		"ts-blocks": "0.11.0"
+	},
+	"changesets": [
+		"brown-phones-know",
+		"empty-camels-smoke",
+		"fast-tips-grow",
+		"friendly-timers-repeat",
+		"good-bulldogs-mate",
+		"healthy-flies-argue",
+		"hip-rivers-swim",
+		"kind-eels-rescue",
+		"kind-news-decide",
+		"late-mails-allow",
+		"lazy-humans-compete",
+		"mean-owls-arrive",
+		"nasty-weeks-whisper",
+		"neat-moons-sparkle",
+		"neat-rockets-build",
+		"olive-cars-relax",
+		"polite-ligers-float",
+		"proud-bags-dance",
+		"shiny-dodos-battle",
+		"soft-mails-worry",
+		"thick-eggs-roll",
+		"tidy-queens-suffer",
+		"tough-crabs-jump",
+		"wise-pumpkins-bake"
+	]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            - name: Check Types
+              run: pnpm check:types
+
             - name: Lint
               run: pnpm check
 

--- a/blocks.json
+++ b/blocks.json
@@ -3,6 +3,5 @@
 	"repos": ["github/ieedan/std"],
 	"path": "src/blocks",
 	"includeTests": false,
-	"imports": "node",
 	"watermark": true
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/ts-blocks"
 	},
-	"keywords": [
-		"blocks",
-		"typescript",
-		"tested",
-		"documented"
-	],
+	"keywords": ["blocks", "typescript", "tested", "documented"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {
@@ -40,7 +35,8 @@
 		"check": "biome check",
 		"ci:release": "tsup && changeset publish",
 		"changeset": "changeset",
-		"test": "vitest"
+		"test": "vitest",
+		"check:types": "tsc"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",

--- a/schema.json
+++ b/schema.json
@@ -18,11 +18,6 @@
 			"type": "boolean",
 			"default": "true"
 		},
-		"imports": {
-			"description": "Controls the `.ts` suffix of relative imports.",
-			"enum": ["deno", "node"],
-			"default": "node"
-		},
 		"watermark": {
 			"description": "When true will add a watermark with the version and repository at the top of the installed files.",
 			"type": "boolean",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -91,30 +91,6 @@ const _init = async (options: Options) => {
 		}
 	}
 
-	let isDeno = false;
-
-	// only check for deno the first time
-	if (initialConfig.isErr()) {
-		// checks if this is a Deno project
-		let isDeno = fs.existsSync('deno.json');
-
-		if (!isDeno && fs.existsSync('jsr.json')) {
-			const result = await confirm({
-				message: `${color.cyan('jsr.json')} detected. Are you using Deno?`,
-				initialValue: true,
-			});
-
-			if (isCancel(result)) {
-				cancel('Canceled!');
-				process.exit(0);
-			}
-
-			isDeno = result;
-		}
-	} else {
-		isDeno = initialConfig.unwrap().imports === 'deno';
-	}
-
 	const config: Config = {
 		$schema: `https://unpkg.com/ts-blocks@${context.package.version}/schema.json`,
 		repos: options.repos,
@@ -123,7 +99,6 @@ const _init = async (options: Options) => {
 			initialConfig.isOk() && options.tests === undefined
 				? initialConfig.unwrap().includeTests
 				: (options.tests ?? false),
-		imports: isDeno ? 'deno' : 'node',
 		watermark: options.watermark,
 	};
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,7 +9,6 @@ const schema = v.object({
 	repos: v.optional(v.array(v.string()), []),
 	includeTests: v.boolean(),
 	path: v.pipe(v.string(), v.minLength(1)),
-	imports: v.optional(v.union([v.literal('deno'), v.literal('node')]), 'node'),
 	watermark: v.optional(v.boolean(), true),
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"module": "ES2022",
 		"target": "ES2022",
 		"skipLibCheck": true,
-		"strict": true
+		"strict": true,
+		"noEmit": true
 	},
 	"include": ["src/**/*.ts", "blocks/**/*.ts"]
 }


### PR DESCRIPTION
This really has already been deprecated but now its officially gone. It hasn't done anything since `includeIndexFile` was removed.

I don't think this one will come back as you would need to implement a way of changing imports for each language and that doesn't really seem practical at the moment.